### PR TITLE
parameterize eds container demands

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 1.2.4 / 2022-06-15
+
+- Parameterize Azure Pipeline container demands
+
 ## 1.2.3 / 2022-05-10
 
 - Updated dependencies

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 | :loudspeaker: **Notice**: Samples have been updated to reflect that they work on AVEVA Data Hub. The samples also work on OSIsoft Cloud Services unless otherwise noted. |
 | -----------------------------------------------------------------------------------------------|
 
-**Version:** 1.2.3
+**Version:** 1.2.4
 
 [![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/ADH/aveva.sample-adh-time_series-python?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=2624&branchName=main)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,10 @@ variables:
   - name: analysisProject
     value: SDS_TS_Python
 
+parameters:
+  - name: containerDemandsEDS
+    default: PYTHON
+
 jobs:
   - job: Tests
     strategy:
@@ -71,7 +75,7 @@ jobs:
   - job: Tests_EDS
     pool:
       name: 00-OSIManaged-Build
-      demands: PYTHON
+      demands: ${{ parameters.containerDemandsEDS }}
     variables:
       - name: TenantId
         value: default


### PR DESCRIPTION
This is to parameterize the pipeline container demands, but the ADH container demands are built off of a matrix with multiple operating system demands, one per job. This will be left as is and not parameterized.